### PR TITLE
ocean_geometry.nc file link + get number of tasks from case

### DIFF
--- a/models/MOM6/cesm_scripts/assimilate.sh
+++ b/models/MOM6/cesm_scripts/assimilate.sh
@@ -8,10 +8,9 @@ set -ex
 
 caseroot=$1
 
-dart_build_dir=/glade/derecho/scratch/hkershaw/MOM6/DART/models/MOM6/work
+dart_build_dir=/glade/work/emilanese/CROCODILE-DART/models/MOM6/work
 comp_name=OCN
 obs_dir=/glade/p/cisl/dares/Observations/WOD13
-ntasks=1152  # should pull this from CIME
 
 echo "DART dart_build_dir" $dart_build_dir
 
@@ -123,14 +122,15 @@ cp $dart_build_dir/input.nml $rundir/input.nml
 
 #-------------------------------
 # set template files for filter
-# restart, static filenames depend on the case
-# ocean_geometry.nc is always called ocean_geometry.nc
+# restart, static, ocean_geometry filenames depend on the case
 #-------------------------------
 setup_template_files() {
 
 ln -sf $(head -1 filter_input_list.txt) mom6.r.nc
 
 ln -sf $(ls $case.mom6.h.static* | head -1) mom6.static.nc
+
+ln -sf $(ls $case.mom6.h.ocean_geometry* | head -1) ocean_geometry.nc
 }
 
 #-------------------------------
@@ -150,7 +150,7 @@ run_filter() {
 
 echo "running filter"
 if [ "$assimilate" = TRUE ]; then
-   mpirun -n $ntasks "$exeroot"/filter
+   mpibind "$exeroot"/filter
 fi
 
 }


### PR DESCRIPTION
## Description:
<!--- Describe your changes -->
CESM now generates a separate $case.mom6.h.ocean_geometry.nc file for each simulation in an ensemble; this PR fixes the compatibility with DART that looks for one file called ocean_geometry.nc.
It also uses the number of tasks already available instead of a fixed value.

### Fixes issue
<!--- link to github issue(s) -->
Fixes #1

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Documentation changes needed?
<!-- Put an `x` in all the boxes that apply: -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

### Tests
The code now runs succesfully with a case generated in CrocoDash
